### PR TITLE
Adding sanity check for IPv4 address

### DIFF
--- a/lib/jgeoip.js
+++ b/lib/jgeoip.js
@@ -565,7 +565,14 @@ function _expandIP(ip) {
     // From: '8.8.4.4'
     // To: [0, 0, 0, 0, 0, 0, 8 * 256 + 8, 4 * 256 + 4]
     //return ip.split('.').map(function(i) { return parseInt(i, 10); });
-    ip = ip.split('.').map(function(i) { return parseInt(i, 10); });
+    ip = ip.split('.').map(function(i) { 
+        var partI = parseInt(i, 10);
+        if(partI > 255) {
+            throw new Error('This IP ' + ip + ' is not a valid IPv4 address!');
+        } else {
+            return partI;
+        } 
+    });
     return [0, 0, 0, 0, 0, 0, ip[0] * 256 + ip[1], ip[2] * 256 + ip[3]];
   }
   else if (regexIPv6c.test(ip)) {


### PR DESCRIPTION
Without the sanity check, it is currently possible to query for a bad IPv4 address such as 500.500.500.500
